### PR TITLE
Add support for title on links

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -16,6 +16,7 @@ type MarkdownNodeMap = {
     },
     link: {
         href: string,
+        title?: string,
         children: MarkdownNode,
     },
     image: {

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -290,13 +290,14 @@ class MarkdownParser {
 
                 this.match('](');
 
-                const href = this.parseText(')');
+                const [href, titleWithEndQuote] = this.parseText(')').split(/\s+"/);
 
                 this.match(')');
 
                 return {
                     type: 'link',
                     href: href,
+                    title: titleWithEndQuote?.slice(0, -1) /* remove quote character at the end */,
                     children: label,
                     source: this.getSlice(startIndex, this.index),
                 };

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -19,6 +19,7 @@ type VisitedMarkdownNodeMap<C> = {
     },
     link: {
         href: string,
+        title?: string,
         children: C,
     },
     image: {
@@ -92,6 +93,7 @@ function visit<T>(node: MarkdownNode, visitor: MarkdownRenderer<T>): T {
             return visitor.link({
                 type: node.type,
                 href: node.href,
+                title: node.title,
                 children: visit(node.children, visitor),
                 source: node.source,
             });

--- a/test/parsing.test.ts
+++ b/test/parsing.test.ts
@@ -1119,6 +1119,36 @@ describe('A Markdown parser function', () => {
                 ],
             },
         },
+        'link with title': {
+            input: 'Hello, [world](image.png "The world")!',
+            output: {
+                type: 'fragment',
+                source: 'Hello, [world](image.png "The world")!',
+                children: [
+                    {
+                        type: 'text',
+                        source: 'Hello, ',
+                        content: 'Hello, ',
+                    },
+                    {
+                        type: 'link',
+                        source: '[world](image.png "The world")',
+                        href: 'image.png',
+                        title: 'The world',
+                        children: {
+                            type: 'text',
+                            source: 'world',
+                            content: 'world',
+                        },
+                    },
+                    {
+                        type: 'text',
+                        source: '!',
+                        content: '!',
+                    },
+                ],
+            },
+        },
         image: {
             input: 'Hello, ![world](image.png)!',
             output: {

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -65,6 +65,7 @@ describe('A Markdown render function', () => {
                 type: 'link',
                 source: node.source,
                 href: node.href,
+                title: node.title,
                 children: node.children,
             };
         }
@@ -86,6 +87,7 @@ describe('A Markdown render function', () => {
         '`Code`',
         '![Image](https://example.com/image.png)',
         '[Link](https://example.com)',
+        '[Link with title](https://example.com "Link title")',
     ].join('\n\n');
 
     const tree: MarkdownNode = {
@@ -191,6 +193,23 @@ describe('A Markdown render function', () => {
                             type: 'text',
                             source: 'Link',
                             content: 'Link',
+                        },
+                    },
+                ],
+            },
+            {
+                type: 'paragraph',
+                source: '[Link with title](https://example.com "Link title")',
+                children: [
+                    {
+                        type: 'link',
+                        source: '[Link with title](https://example.com "Link title")',
+                        href: 'https://example.com',
+                        title: 'Link title',
+                        children: {
+                            type: 'text',
+                            source: 'Link with title',
+                            content: 'Link with title',
                         },
                     },
                 ],


### PR DESCRIPTION
## Summary

The [official Markdown syntax](https://daringfireball.net/projects/markdown/syntax#link) includes support for providing a title on links.

This change adds in code to identify such titles, and add them to the generated AST.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings