### PR TITLE
Add global node index

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,16 +105,14 @@ const markdown = '**Hello**, [World](https://example.com)';
 
 const jsx = render(markdown, {
     text: node => node.content,
-    bold: node => <b>{node.children}</b>,
-    italic: node => <i>{node.children}</i>,
-    strike: node => <s>{node.children}</s>,
-    code: node => <code>{node.content}</code>,
-    link: node => <a href={node.href}>{node.children}</a>,
-    image: node => <img src={node.src} alt={node.alt} />,
-    paragraph: node => <p>{node.children}</p>,
-    fragment: node => node.children.map(
-        (child, index) => <Fragment key={index}>{child}</Fragment>
-    ),
+    bold: node => <b key={node.index}>{node.children}</b>,
+    italic: node => <i key={node.index}>{node.children}</i>,
+    strike: node => <s key={node.index}>{node.children}</s>,
+    code: node => <code key={node.index}>{node.content}</code>,
+    link: node => <a key={node.index} href={node.href}>{node.children}</a>,
+    image: node => <img key={node.index} src={node.src} alt={node.alt} />,
+    paragraph: node => <p key={node.index}>{node.children}</p>,
+    fragment: node => node.children.map(child => <Fragment key={child.index}>{child}</Fragment>),
 });
 ```
 

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -224,4 +224,84 @@ describe('A Markdown render function', () => {
     it('should parse and render a Markdown string', () => {
         expect(render(markdown, new TestRenderer())).toEqual(tree);
     });
+
+    it('should assign a global index to each node', () => {
+        const input = '**Bold**\n*Italic*\n***Bold and italic***\n';
+
+        const result = render<MarkdownNode>(input, {
+            fragment: node => node,
+            text: node => node,
+            bold: node => node,
+            italic: node => node,
+            strike: node => node,
+            code: node => node,
+            image: node => node,
+            link: node => node,
+            paragraph: node => node,
+        });
+
+        expect(result).toEqual({
+            index: 10,
+            type: 'fragment',
+            source: '**Bold**\n*Italic*\n***Bold and italic***\n',
+            children: [
+                {
+                    index: 1,
+                    type: 'bold',
+                    source: '**Bold**',
+                    children: {
+                        index: 0,
+                        type: 'text',
+                        content: 'Bold',
+                        source: 'Bold',
+                    },
+                },
+                {
+                    index: 2,
+                    type: 'text',
+                    content: '\n',
+                    source: '\n',
+                },
+                {
+                    index: 4,
+                    type: 'italic',
+                    source: '*Italic*',
+                    children: {
+                        index: 3,
+                        type: 'text',
+                        content: 'Italic',
+                        source: 'Italic',
+                    },
+                },
+                {
+                    index: 5,
+                    type: 'text',
+                    content: '\n',
+                    source: '\n',
+                },
+                {
+                    index: 8,
+                    type: 'bold',
+                    source: '***Bold and italic***',
+                    children: {
+                        index: 7,
+                        type: 'italic',
+                        source: '*Bold and italic*',
+                        children: {
+                            index: 6,
+                            type: 'text',
+                            content: 'Bold and italic',
+                            source: 'Bold and italic',
+                        },
+                    },
+                },
+                {
+                    index: 9,
+                    type: 'text',
+                    content: '\n',
+                    source: '\n',
+                },
+            ],
+        });
+    });
 });


### PR DESCRIPTION
## Summary
Rendering JSX requires a key, which the developer must handle. To make it easier, this PR adds a new index property with a globally unique index for a given parsing.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings